### PR TITLE
✨ Add new cron for weekly rebuilds

### DIFF
--- a/src/pages/api/cron/rebuild.js
+++ b/src/pages/api/cron/rebuild.js
@@ -1,0 +1,7 @@
+export default async function handler(req, res) {
+  await fetch(
+    'https://api.vercel.com/v1/integrations/deploy/prj_i6vPiRUGzJOS2iUfK75LQQ69DdXL/t9DBDHukj8'
+  );
+
+  res.status(200).end('Rebuilding for new episodes');
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/cron/rebuild",
+      "schedule": "0 1 * * 4"
+    }
+  ]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "crons": [
     {
       "path": "/api/cron/rebuild",
-      "schedule": "0 1 * * 4"
+      "schedule": "0 4 * * 4"
     }
   ]
 }


### PR DESCRIPTION
This will rebuild the site so that `getStaticProps` creates the static page with the correct initial props after a show is published. This will run every Thursday at 1am.